### PR TITLE
settingsdialog: Fix build on older versions of GCC

### DIFF
--- a/src/settingsdialog.cpp
+++ b/src/settingsdialog.cpp
@@ -177,28 +177,24 @@ void SettingsDialog::setupSingleColorEditSlots(QLineEdit* lineEdit,
 	});
 }
 
-template<>
-SettingsDialog::ColorRangeMap& SettingsDialog::artifactCollection()
+template<typename ArtifactT>
+SettingsDialog::ArtifactMap<ArtifactT>& SettingsDialog::artifactCollection()
 {
-	return ranges_;
+	if constexpr (std::is_same_v<ArtifactT, ColorRange>) {
+		return ranges_;
+	} else if constexpr (std::is_same_v<ArtifactT, ColorList>) {
+		return palettes_;
+	}
 }
 
-template<>
-SettingsDialog::ColorListMap& SettingsDialog::artifactCollection()
+template<typename ArtifactT>
+QListWidget* SettingsDialog::artifactSelector()
 {
-	return palettes_;
-}
-
-template<>
-QListWidget* SettingsDialog::artifactSelector<ColorRange>()
-{
-	return ui->colorRangeList;
-}
-
-template<>
-QListWidget* SettingsDialog::artifactSelector<ColorList>()
-{
-	return ui->paletteList;
+	if constexpr (std::is_same_v<ArtifactT, ColorRange>) {
+		return ui->colorRangeList;
+	} else if constexpr (std::is_same_v<ArtifactT, ColorList>) {
+		return ui->paletteList;
+	}
 }
 
 template<typename ArtifactT>

--- a/src/settingsdialog.hpp
+++ b/src/settingsdialog.hpp
@@ -147,23 +147,11 @@ private:
 	template<typename ArtifactT>
 	ArtifactMap<ArtifactT>& artifactCollection();
 
-	template<>
-	ColorRangeMap& artifactCollection();
-
-	template<>
-	ColorListMap& artifactCollection();
-
 	/**
 	 * Retrieves the QListWidget for the specified artifact collection.
 	 */
 	template<typename ArtifactT>
 	QListWidget* artifactSelector();
-
-	template<>
-	QListWidget* artifactSelector<ColorRange>();
-
-	template<>
-	QListWidget* artifactSelector<ColorList>();
 
 	/**
 	 * Retrieves the currently-selected artifact of the specifed type.


### PR DESCRIPTION
GCC 11.4 (found in Ubuntu 22.04 in particular) does NOT support explicit template specialisation in class scope.